### PR TITLE
Add handlers and tests for Pull Request event

### DIFF
--- a/algobot/__main__.py
+++ b/algobot/__main__.py
@@ -37,7 +37,9 @@ async def main(request: web.Request) -> web.Response:
             time_remaining = gh.rate_limit.reset_datetime - datetime.datetime.now(
                 datetime.timezone.utc
             )
-            print(f"GH Ratelimit: {gh.rate_limit} (UTC) which is in {time_remaining}")
+            print(
+                f"GH Ratelimit: {gh.rate_limit} (UTC) which is in {time_remaining}"
+            )  # pragma: no cover
         except AttributeError:
             pass
         return web.Response(status=200)

--- a/algobot/__main__.py
+++ b/algobot/__main__.py
@@ -24,6 +24,10 @@ async def main(request: web.Request) -> web.Response:
         event = sansio.Event.from_http(request.headers, body, secret=secret)
         if event.event == "ping":
             return web.Response(status=200)
+        print(
+            f"Received {event.event + ':' + event.data['action']!r} event "
+            f"with delivery ID: {event.delivery_id}"
+        )
         async with aiohttp.ClientSession() as session:
             gh = gh_aiohttp.GitHubAPI(session, "algorithms-bot", cache=cache)
             # Give GitHub some time to reach internal consistency.
@@ -33,10 +37,7 @@ async def main(request: web.Request) -> web.Response:
             time_remaining = gh.rate_limit.reset_datetime - datetime.datetime.now(
                 datetime.timezone.utc
             )
-            print(
-                f"GH Ratelimit: {gh.rate_limit} (UTC) which is in {time_remaining}\n"
-                f"Received {event.event!r} event with delivery ID: {event.delivery_id}"
-            )
+            print(f"GH Ratelimit: {gh.rate_limit} (UTC) which is in {time_remaining}")
         except AttributeError:
             pass
         return web.Response(status=200)

--- a/algobot/check_runs.py
+++ b/algobot/check_runs.py
@@ -26,11 +26,11 @@ async def check_run_completed(
     installation_id = event.data["installation"]["id"]
     repository = event.data["repository"]["full_name"]
 
-    issue_for_commit = await utils.get_pr_for_commit(
+    pr_for_commit = await utils.get_pr_for_commit(
         gh, installation_id, sha=commit_sha, repository=repository
     )
 
-    if not issue_for_commit:
+    if not pr_for_commit:
         print(
             f"[SKIPPED] Pull request not found for commit: "
             f"https://github.com/{repository}/commit/{commit_sha}"
@@ -52,7 +52,7 @@ async def check_run_completed(
         "in_progress" not in all_check_run_status
         and "queued" not in all_check_run_status
     ):  # wait until all check runs are completed
-        pr_labels = [label["name"] for label in issue_for_commit["labels"]]
+        pr_labels = [label["name"] for label in pr_for_commit["labels"]]
         if any(
             element in [None, "failure", "timed_out"]
             for element in all_check_run_conclusions
@@ -62,7 +62,7 @@ async def check_run_completed(
                     gh,
                     installation_id,
                     label=Label.FAILED_TEST,
-                    pr_or_issue=issue_for_commit,
+                    pr_or_issue=pr_for_commit,
                 )
         # Check run is successful so if the label exist, remove it
         elif Label.FAILED_TEST in pr_labels:
@@ -70,5 +70,5 @@ async def check_run_completed(
                 gh,
                 installation_id,
                 label=Label.FAILED_TEST,
-                pr_or_issue=issue_for_commit,
+                pr_or_issue=pr_for_commit,
             )

--- a/algobot/check_runs.py
+++ b/algobot/check_runs.py
@@ -29,11 +29,17 @@ async def check_run_completed(
     issue_for_commit = await utils.get_issue_for_commit(
         gh, installation_id, sha=commit_sha, repository=repository
     )
-    # The hook came from a check run not made in any pull request
+
     if not issue_for_commit:
         print(
-            f"This commit is not from a PR: "
-            f"https://api.github.com/repos/{repository}/commits/{commit_sha}"
+            f"[SKIPPED] This commit was not from a PR: "
+            f"https://github.com/{repository}/commit/{commit_sha}"
+        )
+        return None
+    elif issue_for_commit["state"] == "closed":
+        print(
+            f"[CLOSED] This PR was closed by {event.data['sender']['login']!r}: "
+            f"{issue_for_commit['pull_request']['html_url']}"
         )
         return None
 

--- a/algobot/check_runs.py
+++ b/algobot/check_runs.py
@@ -26,20 +26,14 @@ async def check_run_completed(
     installation_id = event.data["installation"]["id"]
     repository = event.data["repository"]["full_name"]
 
-    issue_for_commit = await utils.get_issue_for_commit(
+    issue_for_commit = await utils.get_pr_for_commit(
         gh, installation_id, sha=commit_sha, repository=repository
     )
 
     if not issue_for_commit:
         print(
-            f"[SKIPPED] This commit was not from a PR: "
+            f"[SKIPPED] Pull request not found for commit: "
             f"https://github.com/{repository}/commit/{commit_sha}"
-        )
-        return None
-    elif issue_for_commit["state"] == "closed":
-        print(
-            f"[CLOSED] This PR was closed by {event.data['sender']['login']!r}: "
-            f"{issue_for_commit['pull_request']['html_url']}"
         )
         return None
 

--- a/algobot/constants.py
+++ b/algobot/constants.py
@@ -1,0 +1,14 @@
+"""Package level constants
+
+Only the constants which are accessed throughout the module are defined here.
+Constants related to a specific event are defined in their own module. So a
+constant related to pull request will be defined in the `pull_requests` module.
+"""
+
+
+class Label:
+    FAILED_TEST = "Status: Tests are failing"
+    AWAITING_REVIEW = "Status: awaiting reviews"
+    ANNOTATIONS = "Require: Type hints"
+    REQUIRE_TEST = "Require: Tests"
+    DESCRIPTIVE_NAMES = "Require: Descriptive names"

--- a/algobot/parser.py
+++ b/algobot/parser.py
@@ -102,7 +102,7 @@ class PullRequestFilesParser:
 
         return labels_to_add, labels_to_remove
 
-    def create_report_content(self) -> str:  # pragma: no cover
+    def create_report_content(self) -> str:
         """Create the report content for the current pull request as per the
         stored data in the parser.
 

--- a/algobot/parser.py
+++ b/algobot/parser.py
@@ -1,0 +1,204 @@
+import ast
+import functools
+from typing import List, Optional, Union
+
+
+class CodeParser:
+    """Python code parser for all the pull request files.
+
+    This class should only be initialized once per pull request and then use
+    its public method `parse_code` to parse and store all the necessary node
+    paths. Node path will be of the following format:
+
+    `{filepath}:[{class_name}]:{function_name}:{parameter_name}`
+
+    Class name will be added to the path only if the function node is a method.
+
+    Methods:
+        `parse_code(filename: str, code: bytes)`
+            This is main function which will call all the other helper function,
+            do the necessary checks and store the node paths for which the checks
+            failed. All the failed node paths can be accessed using the attributes.
+
+    Attributes (Read only):
+        `require_doctest`: Function node paths which do not contain `doctest`
+        `require_return_annotation`: Function node paths which do not contain return
+                                     annotation
+        `require_annotations`: Parameter node paths which do not contain annotation
+        `require_descriptive_names`: Parameter/Function node paths whose name is
+                                     of length 1
+
+    Attributes:
+        `skip_doctest`: bool, indicating whether to skip doctest checking. This
+                        property can be set as well.
+    """
+
+    def __init__(self) -> None:
+        self._filename = ""
+        self._skip_doctest = False
+        self._require_doctest: List[str] = []
+        self._require_return_annotation: List[str] = []
+        self._require_annotations: List[str] = []
+        self._require_descriptive_names: List[str] = []
+
+    @property
+    def skip_doctest(self) -> bool:
+        """A property indicating whether to check for `doctest` or not. This property
+        can be set after the class is initialized. Default value is `False`."""
+        return self._skip_doctest
+
+    @skip_doctest.setter
+    def skip_doctest(self, value: bool) -> None:
+        assert isinstance(value, bool), value
+        self._skip_doctest = value
+
+    # Caching all the list properties.
+    # NOTE: Do not call the property in any of the methods. Only call it after
+    # all the files are parsed.
+    @functools.cached_property
+    def require_doctest(self) -> List[str]:
+        """Function node path that requires `doctest`. If the function is inside
+        a class, it will include the class name in the path.
+
+        Format:
+        `{filepath}:{function_name}`
+        or
+        `{filepath}:{class_name}:{function_name}`
+        """
+        return self._require_doctest.copy()
+
+    @functools.cached_property
+    def require_return_annotation(self) -> List[str]:
+        """Function node path that requires return annotation. If the function is
+        inside a class, it will include the class name in the path.
+
+        Format:
+        `{filepath}:{function_name}`
+        or
+        `{filepath}:{class_name}:{function_name}`
+        """
+        return self._require_return_annotation.copy()
+
+    @functools.cached_property
+    def require_annotations(self) -> List[str]:
+        """Parameter node path that requires annotation. If the function is inside
+        a class, it will include the class name in the path.
+
+        Format:
+        `{filepath}:{function_name}:{param_name}`
+        or
+        `{filepath}:{class_name}:{function_name}:{param_name}`
+        """
+        return self._require_annotations.copy()
+
+    @functools.cached_property
+    def require_descriptive_names(self) -> List[str]:
+        """Parameter/Function node path that requires descriptive names. If the
+        function is inside a class, it will include the class name in the path.
+
+        Format:
+        `{filepath}:{function_name}`
+        `{filepath}:{function_name}:{param_name}`
+        or
+        `{filepath}:{class_name}:{function_name}`
+        `{filepath}:{class_name}:{function_name}:{param_name}`
+        """
+        return self._require_descriptive_names.copy()
+
+    def parse_code(self, filename: str, code: Union[bytes, str]) -> None:
+        """Parse the Python code for doctest, type hints and descriptive names.
+
+        This is the main function to be called with the filename and the source
+        code in bytes or string format. This will call the other helper function
+        which does the actual parsing and will mutate the property list with the
+        node path for which the tests fail.
+        """
+        self._filename = filename
+        tree = ast.parse(code).body
+        for node in tree:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._parse_function(node)
+            elif isinstance(node, ast.ClassDef):
+                self._parse_class(node)
+
+    def _parse_function(
+        self,
+        function: Union[ast.FunctionDef, ast.AsyncFunctionDef],
+        *,
+        cls_name: Optional[str] = None,
+    ) -> None:
+        # Helper function for parsing the function node
+        # The order of checking is important:
+        #
+        # First check all the function related checks:
+        # - Function name is descriptive or not
+        # - `doctest` is present in the function docstring or not
+        # - Function has return annotation or not
+        #
+        # Then check all the argument related checks:
+        # - Argument name is descriptive or not
+        # - Argument has return annotation or not
+        #
+        # If the `cls_name` argument is not None, it means that the function is inside
+        # the class. This will make sure the node path is constructed appropriately.
+        func_name = function.name
+        if len(func_name) == 1:
+            self._require_descriptive_names.append(
+                self._node_path(func_name=func_name, cls_name=cls_name)
+            )
+        if not self._skip_doctest:
+            docstring = ast.get_docstring(function)
+            if docstring:
+                for line in docstring.split("\n"):
+                    line = line.strip()
+                    if line.startswith(">>>"):
+                        break
+                else:
+                    self._require_doctest.append(
+                        self._node_path(func_name=func_name, cls_name=cls_name)
+                    )
+            # If `docstring` is absent from the function, we will count it as
+            # `doctest` not present.
+            else:
+                self._require_doctest.append(
+                    self._node_path(func_name=func_name, cls_name=cls_name)
+                )
+        if not function.returns:
+            self._require_return_annotation.append(
+                self._node_path(func_name=func_name, cls_name=cls_name)
+            )
+        for arg in function.args.args:
+            arg_name = arg.arg
+            if len(arg_name) == 1:
+                self._require_descriptive_names.append(
+                    self._node_path(
+                        func_name=func_name, cls_name=cls_name, arg_name=arg_name
+                    )
+                )
+            if not arg.annotation:
+                self._require_annotations.append(
+                    self._node_path(
+                        func_name=func_name, cls_name=cls_name, arg_name=arg_name
+                    )
+                )
+
+    def _parse_class(self, klass: ast.ClassDef) -> None:
+        # A method is basically a function inside a class
+        cls_name = klass.name
+        for cls_node in klass.body:
+            if isinstance(cls_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._parse_function(cls_node, cls_name=cls_name)
+
+    def _node_path(
+        self,
+        *,
+        func_name: str,
+        cls_name: Optional[str] = None,
+        arg_name: Optional[str] = None,
+    ) -> str:
+        path: List[str] = [self._filename, func_name]
+        if cls_name:
+            path.insert(1, cls_name)
+        if arg_name:
+            path.append(arg_name)
+        return "`{}`".format(":".join(path))

--- a/algobot/parser.py
+++ b/algobot/parser.py
@@ -10,7 +10,7 @@ class CodeParser:
     its public method `parse_code` to parse and store all the necessary node
     paths. Node path will be of the following format:
 
-    `{filepath}:[{class_name}]:{function_name}:{parameter_name}`
+    `{filepath}::{class_name}::{function_name}::{parameter_name}`
 
     Class name will be added to the path only if the function node is a method.
 
@@ -61,9 +61,9 @@ class CodeParser:
         a class, it will include the class name in the path.
 
         Format:
-        `{filepath}:{function_name}`
+        `{filepath}::{function_name}`
         or
-        `{filepath}:{class_name}:{function_name}`
+        `{filepath}::{class_name}::{function_name}`
         """
         return self._require_doctest.copy()
 
@@ -73,9 +73,9 @@ class CodeParser:
         inside a class, it will include the class name in the path.
 
         Format:
-        `{filepath}:{function_name}`
+        `{filepath}::{function_name}`
         or
-        `{filepath}:{class_name}:{function_name}`
+        `{filepath}::{class_name}::{function_name}`
         """
         return self._require_return_annotation.copy()
 
@@ -85,9 +85,9 @@ class CodeParser:
         a class, it will include the class name in the path.
 
         Format:
-        `{filepath}:{function_name}:{param_name}`
+        `{filepath}::{function_name}::{param_name}`
         or
-        `{filepath}:{class_name}:{function_name}:{param_name}`
+        `{filepath}::{class_name}::{function_name}::{param_name}`
         """
         return self._require_annotations.copy()
 
@@ -97,11 +97,11 @@ class CodeParser:
         function is inside a class, it will include the class name in the path.
 
         Format:
-        `{filepath}:{function_name}`
-        `{filepath}:{function_name}:{param_name}`
+        `{filepath}::{function_name}`
+        `{filepath}::{function_name}::{param_name}`
         or
-        `{filepath}:{class_name}:{function_name}`
-        `{filepath}:{class_name}:{function_name}:{param_name}`
+        `{filepath}::{class_name}::{function_name}`
+        `{filepath}::{class_name}::{function_name}::{param_name}`
         """
         return self._require_descriptive_names.copy()
 
@@ -204,4 +204,4 @@ class CodeParser:
             path.insert(1, cls_name)
         if arg_name:
             path.append(arg_name)
-        return "`{}`".format(":".join(path))
+        return "`{}`".format("::".join(path))

--- a/algobot/parser.py
+++ b/algobot/parser.py
@@ -127,20 +127,21 @@ class CodeParser:
         *,
         cls_name: Optional[str] = None,
     ) -> None:
-        # Helper function for parsing the function node
-        # The order of checking is important:
-        #
-        # First check all the function related checks:
-        # - Function name is descriptive or not
-        # - `doctest` is present in the function docstring or not
-        # - Function has return annotation or not
-        #
-        # Then check all the argument related checks:
-        # - Argument name is descriptive or not
-        # - Argument has return annotation or not
-        #
-        # If the `cls_name` argument is not None, it means that the function is inside
-        # the class. This will make sure the node path is constructed appropriately.
+        """Helper function for parsing the function node
+        The order of checking is important:
+
+        First check all the function related checks:
+        - Function name is descriptive or not
+        - `doctest` is present in the function docstring or not
+        - Function has return annotation or not
+
+        Then check all the argument related checks:
+        - Argument name is descriptive or not
+        - Argument has return annotation or not
+
+        If the `cls_name` argument is not None, it means that the function is inside
+        the class. This will make sure the node path is constructed appropriately.
+        """
         func_name = function.name
         if len(func_name) == 1:
             self._require_descriptive_names.append(
@@ -169,6 +170,8 @@ class CodeParser:
             )
         for arg in function.args.args:
             arg_name = arg.arg
+            if arg_name == "self":
+                continue
             if len(arg_name) == 1:
                 self._require_descriptive_names.append(
                     self._node_path(

--- a/algobot/pull_requests.py
+++ b/algobot/pull_requests.py
@@ -155,6 +155,9 @@ async def close_additional_prs_by_user(
     indicated by the `MAX_PR_BY_USER` constant. This is done so as to avoid spam PRs.
     This limit won't be applied to a member or owner of the organization.
     """
+    if MAX_PR_PER_USER < 1:
+        return
+
     installation_id = event.data["installation"]["id"]
     pull_request = event.data["pull_request"]
     author_association = pull_request["author_association"].lower()

--- a/algobot/pull_requests.py
+++ b/algobot/pull_requests.py
@@ -269,22 +269,23 @@ def labels_to_add_and_remove(
     labels_to_remove = []
 
     # Add or remove REQUIRE_TEST label
-    if parser.require_doctest and Label.REQUIRE_TEST not in pr_labels:
-        labels_to_add.append(Label.REQUIRE_TEST)
+    if parser.require_doctest:
+        if Label.REQUIRE_TEST not in pr_labels:
+            labels_to_add.append(Label.REQUIRE_TEST)
     elif Label.REQUIRE_TEST in pr_labels:
         labels_to_remove.append(Label.REQUIRE_TEST)
 
     # Add or remove DESCRIPTIVE_NAMES label
-    if parser.require_descriptive_names and Label.DESCRIPTIVE_NAMES not in pr_labels:
-        labels_to_add.append(Label.DESCRIPTIVE_NAMES)
+    if parser.require_descriptive_names:
+        if Label.DESCRIPTIVE_NAMES not in pr_labels:
+            labels_to_add.append(Label.DESCRIPTIVE_NAMES)
     elif Label.DESCRIPTIVE_NAMES in pr_labels:
         labels_to_remove.append(Label.DESCRIPTIVE_NAMES)
 
     # Add or remove ANNOTATIONS label
-    if (
-        parser.require_annotations or parser.require_return_annotation
-    ) and Label.ANNOTATIONS not in pr_labels:
-        labels_to_add.append(Label.ANNOTATIONS)
+    if parser.require_annotations or parser.require_return_annotation:
+        if Label.ANNOTATIONS not in pr_labels:
+            labels_to_add.append(Label.ANNOTATIONS)
     elif Label.ANNOTATIONS in pr_labels:
         labels_to_remove.append(Label.ANNOTATIONS)
 

--- a/algobot/pull_requests.py
+++ b/algobot/pull_requests.py
@@ -1,0 +1,334 @@
+import re
+from pathlib import PurePath
+from typing import Any, List, Tuple
+
+from gidgethub import aiohttp as gh_aiohttp
+from gidgethub import routing, sansio
+
+from . import utils
+from .constants import Label
+from .parser import CodeParser
+
+MAX_PR_PER_USER = 1
+
+MAX_PR_REACHED_COMMENT = """\
+# Multiple Pull Request Opened
+
+### Pull request author: @{user_login}
+
+This pull request is being closed as the user already has an open pull request. \
+A user can only have one pull request remain opened at a time. Please focus on \
+your previous pull request before opening another one. Thank you for your cooperation.
+
+User opened pull requests (including this one): {pr_number}
+"""
+
+EMPTY_BODY_COMMENT = """\
+# Invalid Pull Request
+
+### Pull request author: @{user_login}
+
+This pull request is being closed as the description is empty. If this has been done \
+by mistake, please read the [Contributing guidelines]\
+(https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md) and open a new \
+pull request with the provided [pull request template]\
+(https://github.com/TheAlgorithms/Python/blob/master/.github/pull_request_template.md) \
+along with all the appropriate checkboxes marked.
+"""
+
+CHECKBOX_NOT_TICKED_COMMENT = """\
+# Invalid Pull Request
+
+### Pull request author: @{user_login}
+
+This pull request is being closed as none of the checkboxes have been marked. It is \
+important that you go through the checklist and mark the ones relevant to this \
+pull request.
+
+If you're facing any problem on how to mark a checkbox, please read the following \
+instruction:
+- Read a point one at a time and think if it is relevant to the pull request or not.
+- If it is, then mark it by putting a `x` between the square bracket like so: `[x]`
+
+***NOTE: Only `[x]` is supported so if you have put any other letter or symbol \
+between the brackets, that will be marked as invalid. If that is the case then please \
+open a new pull request with the appropriate changes.***
+"""
+
+NO_EXTENSION_COMMENT = """\
+# Invalid Pull Request
+
+### Pull request author: @{user_login}
+
+This pull request is being closed as the files submitted contains no extension. \
+This repository only accepts Python algorithms. Please read the \
+[Contributing guidelines]\
+(https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md) first.
+"""
+
+PR_REPORT_COMMENT = """\
+# Pull Request Report:
+
+### Pull request author: @{user_login}
+
+Hello! Thank you opening the pull request but there are some errors which I detected \
+in the files submitted in this pull request. Please read through the report \
+and make the necessary changes. You can take a look at the relevant links provided \
+after the report.
+{content}
+
+### Relevant links:
+
+- Type hints: https://docs.python.org/3/library/typing.html
+- `doctest`: https://docs.python.org/3/library/doctest.html
+- `unittest`: https://docs.python.org/3/library/unittest.html
+- `pytest`: https://docs.pytest.org/en/stable/
+"""
+
+router = routing.Router()
+
+
+@router.register("pull_request", action="opened")
+async def close_invalid_pr(
+    event: sansio.Event,
+    gh: gh_aiohttp.GitHubAPI,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Close an invalid pull request and dismiss all the review request from it.
+    The review request will be coming from the CODEOWNERS file.
+
+    A pull request is considered invalid if:
+    - It doesn't contain any description
+    - The user has not ticked any of the checkboxes in the pull request template
+    - The file extension is invalid (Extensionless files) [This will be checked in
+      `check_pr_files` function]
+
+    These checks won't be done for the pull request made by a member or owner of the
+    organization.
+    """
+    installation_id = event.data["installation"]["id"]
+    pull_request = event.data["pull_request"]
+
+    if pull_request["author_association"] in {"OWNER", "MEMBER"}:
+        return None
+
+    pr_body = pull_request["body"]
+    pr_author = pull_request["user"]["login"]
+    comment = None
+    if not pr_body:
+        comment = EMPTY_BODY_COMMENT.format(user_login=pr_author)
+    elif not re.search(r"\[x]", pr_body):
+        comment = CHECKBOX_NOT_TICKED_COMMENT.format(user_login=pr_author)
+
+    if comment:
+        await utils.close_pr_or_issue(
+            gh,
+            installation_id,
+            comment=comment,
+            pr_or_issue=pull_request,
+            label="invalid",
+        )
+
+        # We only want to dismiss the review request when a PR is invalid
+        if pull_request["requested_reviewers"]:
+            await utils.remove_requested_reviewers_from_pr(
+                gh, installation_id, pull_request=pull_request
+            )
+
+
+@router.register("pull_request", action="opened")
+async def close_additional_prs_by_user(
+    event: sansio.Event,
+    gh: gh_aiohttp.GitHubAPI,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Close additional pull requests made by the user.
+
+    A user will be allowed a fix number of pull requests at a time which will be
+    indicated by the `MAX_PR_BY_USER` constant. This is done so as to avoid spam PRs.
+    This limit won't be applied to a member or owner of the organization.
+    """
+    installation_id = event.data["installation"]["id"]
+    pull_request = event.data["pull_request"]
+
+    if pull_request["author_association"] in {"OWNER", "MEMBER"}:
+        return None
+
+    pr_author = pull_request["user"]["login"]
+
+    user_pr_numbers = await utils.get_total_open_prs(
+        gh,
+        installation_id,
+        repository=event.data["repository"]["full_name"],
+        user_login=pr_author,
+        count=False,
+    )
+    if len(user_pr_numbers) > MAX_PR_PER_USER:
+        pr_number = "#{}".format(", #".join(str(num) for num in user_pr_numbers))
+        await utils.close_pr_or_issue(
+            gh,
+            installation_id,
+            comment=MAX_PR_REACHED_COMMENT.format(
+                user_login=pr_author, pr_number=pr_number
+            ),
+            pr_or_issue=pull_request,
+        )
+
+
+@router.register("pull_request", action="opened")
+@router.register("pull_request", action="synchronize")
+async def check_pr_files(
+    event: sansio.Event,
+    gh: gh_aiohttp.GitHubAPI,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Check all the pull request files for extension, type hints, tests and function
+    and parameter names.
+
+    This function will accomplish the following tasks:
+    - Check for file extension and close the PR if a file do not contain any extension.
+      Ignores all non-python files.
+    - Check for type hints and tests in the submitted files and label it appropriately
+      (close it when there are more number of open PRs)
+
+    This function will also be triggered when new commits are pushed to the PR.
+    """
+    installation_id = event.data["installation"]["id"]
+    pull_request = event.data["pull_request"]
+
+    pr_labels = [label["name"] for label in pull_request["labels"]]
+    pr_author = pull_request["user"]["login"]
+    pr_files = await utils.get_pr_files(gh, installation_id, pull_request=pull_request)
+    parser = CodeParser()
+    files_to_check = []
+
+    # We will collect the files first as there is this one problem case:
+    # PR with `main.py` and `test_main.py`
+    # If in this loop, the main file came first, we will check for `doctest` even though
+    # there is a separate test file. We cannot hope that the test file comes first in
+    # the loop.
+    for file in pr_files:
+        filepath = PurePath(file["filename"])
+        # If files do not contain any extension then the PR is invalid
+        # Ignores the .github directory as that might contain extensionless files
+        if not filepath.suffix and ".github" not in filepath.parts:
+            await utils.close_pr_or_issue(
+                gh,
+                installation_id,
+                comment=NO_EXTENSION_COMMENT.format(user_login=pr_author),
+                pr_or_issue=pull_request,
+                label="invalid",
+            )
+            return None
+        elif filepath.suffix != ".py" or filepath.name.startswith("__"):
+            continue
+        # If there is a test file then we do not want to check for `doctest`.
+        # NOTE: This should come after the check for `.py` files.
+        elif filepath.name.startswith("test") or filepath.name.endswith("test.py"):
+            parser.skip_doctest = True
+        files_to_check.append(file)
+
+    for file in files_to_check:
+        code = await utils.get_file_content(gh, installation_id, file=file)
+        parser.parse_code(file["filename"], code)
+
+    labels_to_add, labels_to_remove = labels_to_add_and_remove(parser, pr_labels)
+
+    if labels_to_add:
+        await utils.add_label_to_pr_or_issue(
+            gh, installation_id, label=labels_to_add, pr_or_issue=pull_request
+        )
+
+    # We can only remove labels one at a time or all at once.
+    for remove_label in labels_to_remove:
+        await utils.remove_label_from_pr_or_issue(
+            gh, installation_id, label=remove_label, pr_or_issue=pull_request
+        )
+
+    # Comment the report data only when the pull request is opened.
+    if event.data["action"] == "opened":
+        report = create_pr_report(parser, pr_author)
+        await utils.add_comment_to_pr_or_issue(
+            gh, installation_id, comment=report, pr_or_issue=pull_request
+        )
+
+
+def labels_to_add_and_remove(
+    parser: CodeParser, pr_labels: List[str]
+) -> Tuple[List[str], List[str]]:
+    """Return which labels to add and remove from the given pull request according
+    to the CodeParser object given.
+
+    The attributes of the parser object and the current labels will determine which
+    labels to add or remove.
+    """
+    labels_to_add = []
+    labels_to_remove = []
+
+    # Add or remove REQUIRE_TEST label
+    if parser.require_doctest and Label.REQUIRE_TEST not in pr_labels:
+        labels_to_add.append(Label.REQUIRE_TEST)
+    elif Label.REQUIRE_TEST in pr_labels:
+        labels_to_remove.append(Label.REQUIRE_TEST)
+
+    # Add or remove DESCRIPTIVE_NAMES label
+    if parser.require_descriptive_names and Label.DESCRIPTIVE_NAMES not in pr_labels:
+        labels_to_add.append(Label.DESCRIPTIVE_NAMES)
+    elif Label.DESCRIPTIVE_NAMES in pr_labels:
+        labels_to_remove.append(Label.DESCRIPTIVE_NAMES)
+
+    # Add or remove ANNOTATIONS label
+    if (
+        parser.require_annotations or parser.require_return_annotation
+    ) and Label.ANNOTATIONS not in pr_labels:
+        labels_to_add.append(Label.ANNOTATIONS)
+    elif Label.ANNOTATIONS in pr_labels:
+        labels_to_remove.append(Label.ANNOTATIONS)
+
+    return labels_to_add, labels_to_remove
+
+
+def create_pr_report(parser: CodeParser, user_login: str) -> str:
+    """Create the report for the current pull request as per the stored data
+    in the parser.
+
+    The report comment will be in the following format:
+
+    ---
+    {PR_REPORT_COMMENT}
+
+    ### {Following functions/parameters require ...},
+        where '...' can be tests, type hints, etc
+    - [ ] Function or parameter node path where the requirement is missing
+    ---
+
+    NOTE: The report will only contain missing requirements.
+    """
+    content = []
+
+    if parser.require_doctest:
+        content.append(
+            "\n### Following functions require tests [`doctest`/`unittest`/`pytest`]:\n"
+            "- [ ] {}\n".format("\n- [ ] ".join(parser.require_doctest))
+        )
+    if parser.require_descriptive_names:
+        content.append(
+            "\n### Following functions/parameters require descriptive names:\n"
+            "- [ ] {}\n".format("\n- [ ] ".join(parser.require_descriptive_names))
+        )
+    if parser.require_return_annotation:
+        content.append(
+            "\n### Following functions require return type hints:\n"
+            "***NOTE: If the function returns `None` then provide the type hint as "
+            "`def function() -> None`***\n"
+            "- [ ] {}\n".format("\n- [ ] ".join(parser.require_return_annotation))
+        )
+    if parser.require_annotations:
+        content.append(
+            "\n### Following function parameters require type hints:\n"
+            "- [ ] {}\n".format("\n- [ ] ".join(parser.require_annotations))
+        )
+    return PR_REPORT_COMMENT.format(content="".join(content), user_login=user_login)

--- a/algobot/pull_requests.py
+++ b/algobot/pull_requests.py
@@ -201,7 +201,7 @@ async def check_pr_files(
             continue
         # If there is a test file then we do not want to check for `doctest`.
         # NOTE: This should come after the check for `.py` files.
-        elif filepath.name.startswith("test") or filepath.name.endswith("test.py"):
+        elif filepath.name.startswith("test") or filepath.name.endswith("_test.py"):
             parser.skip_doctest = True
         files_to_check.append(file)
 

--- a/algobot/pull_requests.py
+++ b/algobot/pull_requests.py
@@ -155,8 +155,9 @@ async def close_additional_prs_by_user(
     indicated by the `MAX_PR_BY_USER` constant. This is done so as to avoid spam PRs.
     This limit won't be applied to a member or owner of the organization.
     """
+    # In case we want to stop the checks for all users
     if MAX_PR_PER_USER < 1:
-        return
+        return None
 
     installation_id = event.data["installation"]["id"]
     pull_request = event.data["pull_request"]

--- a/algobot/pull_requests.py
+++ b/algobot/pull_requests.py
@@ -283,7 +283,7 @@ async def check_pr_files(
                 gh,
                 installation_id,
                 comment=PR_REPORT_COMMENT.format(
-                    content=report_content, user_login=pr_author
+                    content="".join(report_content), user_login=pr_author
                 ),
                 pr_or_issue=pull_request,
             )

--- a/algobot/utils.py
+++ b/algobot/utils.py
@@ -156,7 +156,7 @@ async def get_total_open_prs(
     we can make a search API call for open pull requests.
     """
     installation_access_token = await get_access_token(gh, installation_id)
-    search_url = f"/searh/issues?q=type:pr+state:open+repo:{repository}"
+    search_url = f"/search/issues?q=type:pr+state:open+repo:{repository}"
     if user_login:
         search_url += f"+author:{user_login}"
     if not count:

--- a/algobot/utils.py
+++ b/algobot/utils.py
@@ -40,21 +40,19 @@ async def get_access_token(gh: gh_aiohttp.GitHubAPI, installation_id: int) -> st
     return cache["access_token"]
 
 
-async def get_issue_for_commit(
+async def get_pr_for_commit(
     gh: gh_aiohttp.GitHubAPI, installation_id: int, *, sha: str, repository: str
 ) -> Union[None, Dict[str, Any]]:
-    """Return the issue object for the given SHA of a commit.
+    """Return the issue object relative to the pull request, for the given SHA
+    of a commit.
 
     GitHub's REST API v3 considers every pull request an issue, but not every issue
     is a pull request. This means when we search for a pull request, we get the issue
     object with the pull request url information in it as `issue["pull_request"]`.
-
-    If `issue["pull_request"]` is an empty `dict` then the associated object
-    is actually an issue and not a pull request.
     """
     installation_access_token = await get_access_token(gh, installation_id)
     data = await gh.getitem(
-        f"/search/issues?q=type:pr+repo:{repository}+sha:{sha}",
+        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}",
         oauth_token=installation_access_token,
     )
     if data["total_count"] > 0:

--- a/algobot/utils.py
+++ b/algobot/utils.py
@@ -245,4 +245,4 @@ async def get_file_content(
     """Return the file content decoded into Python bytes object."""
     installation_access_token = await get_access_token(gh, installation_id)
     data = await gh.getitem(file["contents_url"], oauth_token=installation_access_token)
-    return base64.decodebytes(data["content"])
+    return base64.decodebytes(data["content"].encode())

--- a/tests/data/no_errors.py
+++ b/tests/data/no_errors.py
@@ -1,0 +1,34 @@
+def no_error_func(num: int, name: str, outcome: bool) -> None:
+    """No error function
+    >>> all_args(1, "a", True)
+    None
+    """
+    return None
+
+
+def helper(limit: int = 10) -> None:
+    """Helper function
+    >>> helper()
+    None
+    """
+    return None
+
+
+class ClassTest:
+    def __init__(self, start: int) -> None:
+        """No point in having doctest in here"""
+        self.start = start
+
+    def cls_no_error_func(self, num: int, name: str, outcome: bool) -> None:
+        """No error function
+        >>> all_args(1, "a", True)
+        None
+        """
+        return None
+
+    def cls_helper(self, limit: int = 10) -> None:
+        """Helper function
+        >>> helper()
+        None
+        """
+        return None

--- a/tests/data/require_annotations.py
+++ b/tests/data/require_annotations.py
@@ -1,0 +1,57 @@
+def all_annotations(num, test) -> None:
+    """All arguments require annotations
+    >>> no_annotations(1, "a")
+    None
+    """
+    return None
+
+
+def some_annotations(num: int, test) -> None:
+    """Some arguments require annotations
+    >>> some_args(1, "a")
+    None
+    """
+    return None
+
+
+def no_annotations(num: int, boolean: bool) -> None:
+    """No arguments require annotations
+    >>> no_args(1, True)
+    None
+    """
+    return None
+
+
+def self_in_function(self=1) -> None:
+    """A function containing `self` argument should not be ignored
+    >>> self_in_function()
+    None
+    """
+    return None
+
+
+class ClassTest:
+    def __init__(self, num) -> None:
+        """__init__ requires annotation"""
+        self.num = num
+
+    def cls_all_annotations(self, num, test) -> None:
+        """All arguments require annotations
+        >>> cls_no_annotations(1, "a")
+        None
+        """
+        return None
+
+    def cls_some_annotations(self, num: int, test) -> None:
+        """Some arguments require annotations
+        >>> cls_some_annotations(1, "a")
+        None
+        """
+        return None
+
+    def cls_no_annotations(self, num: int, boolean: bool) -> None:
+        """No arguments require annotations
+        >>> cls_no_annotations(1, True)
+        None
+        """
+        return None

--- a/tests/data/require_descriptive_names.py
+++ b/tests/data/require_descriptive_names.py
@@ -1,0 +1,70 @@
+def all_args(a: int, b: str, c: bool) -> None:
+    """All arguments require descriptive names
+    >>> all_args(1, "a", True)
+    None
+    """
+    return None
+
+
+def some_args(num: int, s: str, b: bool) -> None:
+    """Some arguments require descriptive names
+    >>> some_args(1, "a", True)
+    None
+    """
+    return None
+
+
+def no_args(num: int, boolean: bool) -> None:
+    """No arguments require descriptive names
+    >>> no_args(1, True)
+    None
+    """
+    return None
+
+
+def f(a: int = 10) -> None:
+    """Function and argument both require descriptive names
+    >>> f()
+    None
+    """
+    return None
+
+
+class ClassTest:
+    def __init__(self, a: int) -> None:
+        """No point in having doctest in here"""
+        self.a = a
+
+    def cls_all_args(self, a: int, b: str, c: bool) -> None:
+        """All arguments require descriptive names
+        >>> cls_all_args(1, "a", True)
+        None
+        """
+        return None
+
+    def cls_some_args(self, num: int, s: str, b: bool) -> None:
+        """Some arguments require descriptive names
+        >>> cls_some_args(1, "a", True)
+        None
+        """
+        return None
+
+    def cls_no_args(self, num: int, boolean: bool) -> None:
+        """No arguments require descriptive names
+        >>> cls_no_args(1, True)
+        None
+        """
+        return None
+
+    def c(self, a: int = 10) -> None:
+        """Function and argument both require descriptive names
+        >>> c()
+        None
+        """
+        return None
+
+
+class C:
+    """A class which requires descriptive names"""
+
+    pass

--- a/tests/data/require_doctest.py
+++ b/tests/data/require_doctest.py
@@ -1,0 +1,43 @@
+def no_doctest() -> None:
+    """
+    This function contains docstring but no doctest
+    """
+    return None
+
+
+# This function do not contain docstring and doctest
+def no_docstring_and_doctest() -> None:
+    return None
+
+
+def contains_doctest(num: int = 10) -> int:
+    """
+    This function contains docstring and doctest
+    >>> contains_doctest()
+    15
+    """
+    return num + 5
+
+
+class ClassTest:
+    def __init__(self, num: int) -> None:
+        """No point in having doctest in here"""
+        self.num = num
+
+    def cls_no_doctest(self) -> None:
+        """
+        This function contains docstring but no doctest
+        """
+        return None
+
+    # This function do not contain docstring and doctest
+    def cls_no_docstring_and_doctest(self) -> None:
+        return None
+
+    def cls_contains_doctest(self, num: int = 10) -> int:
+        """
+        This function contains docstring and doctest
+        >>> cls_contains_doctest()
+        15
+        """
+        return num + 5

--- a/tests/data/require_return_annotation.py
+++ b/tests/data/require_return_annotation.py
@@ -1,0 +1,38 @@
+def no_annotation(num: int):
+    """
+    This function contains no return annotation
+    >>> no_annotation(5)
+    10
+    """
+    return num + 5
+
+
+def contains_annotation(num: int) -> None:
+    """
+    This function contains return annotation
+    >>> contains_annotation()
+    None
+    """
+    return None
+
+
+class ClassTest:
+    def __init__(self, test: int):
+        """This function contatins no return annotation"""
+        self.test = test
+
+    def cls_no_annotation(self, num: int):
+        """
+        This function contains no return annotation
+        >>> cls_no_annotation(5)
+        10
+        """
+        return num + 5
+
+    def cls_contains_annotation(self, num: int) -> None:
+        """
+        This function contains return annotation
+        >>> cls_contains_annotation()
+        None
+        """
+        return None

--- a/tests/test_check_runs.py
+++ b/tests/test_check_runs.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from gidgethub import apps, sansio
@@ -7,7 +9,16 @@ from algobot.constants import Label
 
 from .utils import MOCK_INSTALLATION_ID, MockGitHubAPI, mock_return
 
-BASE_URL = "https://api.github.com"
+# Common constants
+number = 1
+repository = "TheAlgorithms/Python"
+sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
+
+# Incomplete urls
+html_pr_url = f"https://github.com/{repository}/pulls/{number}"
+search_url = f"/search/issues?q=type:pr+repo:{repository}+sha:{sha}"
+check_run_url = f"/repos/{repository}/commits/{sha}/check-runs"
+labels_url = f"https://api.github.com/repos/{repository}/issues/{number}/labels"
 
 
 def setup_module(module, monkeypatch=MonkeyPatch()):
@@ -26,7 +37,6 @@ def setup_module(module, monkeypatch=MonkeyPatch()):
 
 @pytest.mark.asyncio
 async def test_check_run_created():
-    repository = "TheAlgorithms/Python"
     data = {
         "action": "created",
         "check_run": {
@@ -41,12 +51,11 @@ async def test_check_run_created():
     gh = MockGitHubAPI()
     result = await check_runs.router.dispatch(event, gh)
     assert result is None
+    assert gh.getitem_url == []
 
 
 @pytest.mark.asyncio
 async def test_check_run_not_from_pr_commit():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
     data = {
         "action": "completed",
         "check_run": {
@@ -60,25 +69,57 @@ async def test_check_run_not_from_pr_commit():
     }
     event = sansio.Event(data, event="check_run", delivery_id="2")
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 0,
-            "incomplete_results": False,
             "items": [],
         }
     }
     gh = MockGitHubAPI(getitem=getitem)
     result = await check_runs.router.dispatch(event, gh)
-    assert (
-        gh.getitem_url
-        == f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}"
-    )
+    assert len(gh.getitem_url) == 1
+    assert gh.getitem_url[0] == search_url
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_run_pr_closed():
+    data = {
+        "action": "completed",
+        "check_run": {
+            "head_sha": sha,
+            "status": "completed",
+            "conclusion": "success",
+        },
+        "name": "pre-commit",
+        "repository": {"full_name": repository},
+        "sender": {"login": "dhruvmanila"},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="check_run", delivery_id="2")
+    getitem = {
+        search_url: {
+            "total_count": 1,
+            "items": [
+                {
+                    "number": number,
+                    "state": "closed",
+                    "pull_request": {"html_url": html_pr_url},
+                }
+            ],
+        }
+    }
+    gh = MockGitHubAPI(getitem=getitem)
+    result = await check_runs.router.dispatch(event, gh)
+    assert len(gh.getitem_url) == 1
+    assert gh.getitem_url[0] == search_url
+    assert gh.post_url == []  # does not add any label
+    assert gh.post_data == []
+    assert gh.delete_url == []  # does not delete any label
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_check_run_completed_some_in_progress():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
     data = {
         "action": "completed",
         "check_run": {
@@ -92,13 +133,11 @@ async def test_check_run_completed_some_in_progress():
     }
     event = sansio.Event(data, event="check_run", delivery_id="3")
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 1,
-            "incomplete_results": False,
             "items": [
                 {
-                    "number": 3378,
-                    "title": "Create GitHub action only for Project Euler",
+                    "number": number,
                     "state": "open",
                     "labels": [
                         {"name": "Status: awaiting reviews"},
@@ -106,7 +145,7 @@ async def test_check_run_completed_some_in_progress():
                 }
             ],
         },
-        f"/repos/{repository}/commits/{sha}/check-runs": {
+        check_run_url: {
             "total_count": 2,
             "check_runs": [
                 {
@@ -125,15 +164,15 @@ async def test_check_run_completed_some_in_progress():
     gh = MockGitHubAPI(getitem=getitem)
     result = await check_runs.router.dispatch(event, gh)
     assert result is None
-    assert gh.post_data is None  # does not add any label
-    assert gh.post_url is None
-    assert gh.delete_url is None  # does not delete any label
+    assert len(gh.getitem_url) == 2
+    assert gh.getitem_url == [search_url, check_run_url]
+    assert gh.post_data == []
+    assert gh.post_url == []  # does not add any label
+    assert gh.delete_url == []  # does not delete any label
 
 
 @pytest.mark.asyncio
 async def test_check_run_completed_passing_no_label():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
     data = {
         "action": "completed",
         "check_run": {
@@ -147,13 +186,11 @@ async def test_check_run_completed_passing_no_label():
     }
     event = sansio.Event(data, event="check_run", delivery_id="4")
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 1,
-            "incomplete_results": False,
             "items": [
                 {
-                    "number": 3378,
-                    "title": "Create GitHub action only for Project Euler",
+                    "number": number,
                     "state": "open",
                     "labels": [
                         {"name": "Status: awaiting reviews"},
@@ -161,7 +198,7 @@ async def test_check_run_completed_passing_no_label():
                 }
             ],
         },
-        f"/repos/{repository}/commits/{sha}/check-runs": {
+        check_run_url: {
             "total_count": 2,
             "check_runs": [
                 {
@@ -180,15 +217,16 @@ async def test_check_run_completed_passing_no_label():
     gh = MockGitHubAPI(getitem=getitem)
     result = await check_runs.router.dispatch(event, gh)
     assert result is None
-    assert gh.post_data is None  # does not add any label
-    assert gh.post_url is None
-    assert gh.delete_url is None  # does not delete any label
+    assert len(gh.getitem_url) == 2
+    assert gh.getitem_url == [search_url, check_run_url]
+    assert gh.post_data == []
+    assert gh.post_url == []  # does not add any label
+    assert gh.delete_url == []  # does not delete any label
 
 
 @pytest.mark.asyncio
 async def test_check_run_completed_passing_with_label():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
+    rm_labels_url = f"{labels_url}/{urllib.parse.quote(Label.FAILED_TEST)}"
     data = {
         "action": "completed",
         "check_run": {
@@ -202,23 +240,21 @@ async def test_check_run_completed_passing_with_label():
     }
     event = sansio.Event(data, event="check_run", delivery_id="5")
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 1,
-            "incomplete_results": False,
             "items": [
                 {
-                    "number": 3378,
-                    "title": "Create GitHub action only for Project Euler",
+                    "number": number,
                     "state": "open",
                     "labels": [
                         {"name": "Status: awaiting reviews"},
                         {"name": Label.FAILED_TEST},
                     ],
-                    "labels_url": f"{BASE_URL}/repos/{repository}/issues/3378/labels",
+                    "labels_url": labels_url,
                 }
             ],
         },
-        f"/repos/{repository}/commits/{sha}/check-runs": {
+        check_run_url: {
             "total_count": 2,
             "check_runs": [
                 {
@@ -234,21 +270,19 @@ async def test_check_run_completed_passing_with_label():
             ],
         },
     }
-    delete = [{"name": "Status: awaiting reviews"}]
+    delete = {rm_labels_url: [{"name": "Status: awaiting reviews"}]}
     gh = MockGitHubAPI(getitem=getitem, delete=delete)
     result = await check_runs.router.dispatch(event, gh)
     assert result is None
-    assert gh.post_data is None  # does not add any label
-    assert gh.delete_url == (
-        f"{BASE_URL}/repos/{repository}/issues/3378/labels/"
-        f"Status%3A%20Tests%20are%20failing"
-    )
+    assert len(gh.getitem_url) == 2
+    assert gh.getitem_url == [search_url, check_run_url]
+    assert gh.post_url == []
+    assert gh.post_data == []  # does not add any label
+    assert gh.delete_url[0] == rm_labels_url
 
 
 @pytest.mark.asyncio
 async def test_check_run_completed_failing_no_label():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
     data = {
         "action": "completed",
         "check_run": {
@@ -262,22 +296,20 @@ async def test_check_run_completed_failing_no_label():
     }
     event = sansio.Event(data, event="check_run", delivery_id="6")
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 1,
-            "incomplete_results": False,
             "items": [
                 {
-                    "number": 3378,
-                    "title": "Create GitHub action only for Project Euler",
+                    "number": number,
                     "state": "open",
                     "labels": [
                         {"name": "Status: awaiting reviews"},
                     ],
-                    "labels_url": f"{BASE_URL}/repos/{repository}/issues/3378/labels",
+                    "labels_url": labels_url,
                 }
             ],
         },
-        f"/repos/{repository}/commits/{sha}/check-runs": {
+        check_run_url: {
             "total_count": 2,
             "check_runs": [
                 {
@@ -293,22 +325,24 @@ async def test_check_run_completed_failing_no_label():
             ],
         },
     }
-    post = [
-        {"name": "Status: awaiting reviews"},
-        {"name": Label.FAILED_TEST},
-    ]
+    post = {
+        labels_url: [
+            {"name": "Status: awaiting reviews"},
+            {"name": Label.FAILED_TEST},
+        ]
+    }
     gh = MockGitHubAPI(getitem=getitem, post=post)
     result = await check_runs.router.dispatch(event, gh)
     assert result is None
-    assert gh.delete_url is None  # does not delete any label
-    assert gh.post_url == f"{BASE_URL}/repos/{repository}/issues/3378/labels"
-    assert gh.post_data == {"labels": [Label.FAILED_TEST]}
+    assert len(gh.getitem_url) == 2
+    assert gh.getitem_url == [search_url, check_run_url]
+    assert gh.delete_url == []  # does not delete any label
+    assert gh.post_url[0] == labels_url
+    assert gh.post_data[0] == {"labels": [Label.FAILED_TEST]}
 
 
 @pytest.mark.asyncio
 async def test_check_run_completed_failing_with_label():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
     data = {
         "action": "completed",
         "check_run": {
@@ -322,23 +356,21 @@ async def test_check_run_completed_failing_with_label():
     }
     event = sansio.Event(data, event="check_run", delivery_id="7")
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 1,
-            "incomplete_results": False,
             "items": [
                 {
-                    "number": 3378,
-                    "title": "Create GitHub action only for Project Euler",
+                    "number": number,
                     "state": "open",
                     "labels": [
                         {"name": "Status: awaiting reviews"},
                         {"name": Label.FAILED_TEST},
                     ],
-                    "labels_url": f"{BASE_URL}/repos/{repository}/issues/3378/labels",
+                    "labels_url": check_run_url,
                 }
             ],
         },
-        f"/repos/{repository}/commits/{sha}/check-runs": {
+        check_run_url: {
             "total_count": 2,
             "check_runs": [
                 {
@@ -357,6 +389,8 @@ async def test_check_run_completed_failing_with_label():
     gh = MockGitHubAPI(getitem=getitem)
     result = await check_runs.router.dispatch(event, gh)
     assert result is None
-    assert gh.post_data is None  # does not add any label
-    assert gh.post_url is None
-    assert gh.delete_url is None  # does not delete any label
+    assert len(gh.getitem_url) == 2
+    assert gh.getitem_url == [search_url, check_run_url]
+    assert gh.post_data == []  # does not add any label
+    assert gh.post_url == []
+    assert gh.delete_url == []  # does not delete any label

--- a/tests/test_check_runs.py
+++ b/tests/test_check_runs.py
@@ -21,18 +21,11 @@ check_run_url = f"/repos/{repository}/commits/{sha}/check-runs"
 labels_url = f"https://api.github.com/repos/{repository}/issues/{number}/labels"
 
 
-def setup_module(module, monkeypatch=MonkeyPatch()):
-    """Monkeypatch for this module to store the MOCK_TOKEN in cache.
-
-    We cannot use `pytest.fixture(scope="module")` as `monkeypatch` fixture
-    only works at function level (this is a module level setup function),
-    so we will directly use the MonkeyPatch class where the fixture is
-    generated from and pass it as the default argument to this function.
-
-    This will only be executed once in this module, storing the token in the
-    cache for later use.
-    """
+@pytest.fixture(scope="module", autouse=True)
+def patch_module(monkeypatch=MonkeyPatch()):
     monkeypatch.setattr(apps, "get_installation_access_token", mock_return)
+    yield monkeypatch
+    monkeypatch.undo()
 
 
 @pytest.mark.asyncio

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -6,6 +6,11 @@ from algobot import installations
 
 from .utils import MOCK_INSTALLATION_ID, MockGitHubAPI, mock_return
 
+repository = "TheAlgorithms/Python"
+number = 1
+
+issue_url = f"https://api.github.com/repos/{repository}/issues/{number}"
+
 
 def setup_module(module, monkeypatch=MonkeyPatch()):
     """Monkeypatch for this module to store the MOCK_TOKEN in cache.
@@ -23,7 +28,6 @@ def setup_module(module, monkeypatch=MonkeyPatch()):
 
 @pytest.mark.asyncio
 async def test_installation_created():
-    repository = "dhruvmanila/testing"
     data = {
         "action": "created",
         "installation": {"id": MOCK_INSTALLATION_ID},
@@ -33,38 +37,42 @@ async def test_installation_created():
     event = sansio.Event(data, event="installation", delivery_id="1")
 
     post = {
-        "url": "https://api.github.com/repos/dhruvmanila/testing/issues/8",
-        "number": 8,
-        "title": "Installation successful!",
-        "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
-        "state": "open",
-        "body": (
-            "This is the Algorithms bot at your service! "
-            "Thank you for installing me @dhruvmanila"
-        ),
+        f"/repos/{repository}/issues": {
+            "url": issue_url,
+            "number": number,
+            "title": "Installation successful!",
+            "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
+            "state": "open",
+            "body": (
+                "This is the Algorithms bot at your service! "
+                "Thank you for installing me @dhruvmanila"
+            ),
+        }
     }
     patch = {
-        "url": "https://api.github.com/repos/dhruvmanila/testing/issues/8",
-        "number": 8,
-        "title": "Installation successful!",
-        "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
-        "state": "closed",
-        "body": (
-            "This is the Algorithms bot at your service! "
-            "Thank you for installing me @dhruvmanila"
-        ),
+        issue_url: {
+            "url": issue_url,
+            "number": number,
+            "title": "Installation successful!",
+            "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
+            "state": "closed",
+            "body": (
+                "This is the Algorithms bot at your service! "
+                "Thank you for installing me @dhruvmanila"
+            ),
+        }
     }
 
     gh = MockGitHubAPI(post=post, patch=patch)
     await installations.router.dispatch(event, gh)
-    assert gh.post_url == f"/repos/{repository}/issues"
-    assert gh.post_data["title"] == "Installation successful!"
-    assert gh.post_data["body"] == (
+    assert gh.post_url[0] == f"/repos/{repository}/issues"
+    assert gh.post_data[0]["title"] == "Installation successful!"
+    assert gh.post_data[0]["body"] == (
         "This is the Algorithms bot at your service! "
         "Thank you for installing me @dhruvmanila"
     )
-    assert gh.patch_url == "https://api.github.com/repos/dhruvmanila/testing/issues/8"
-    assert gh.patch_data["state"] == "closed"
+    assert gh.patch_url[0] == issue_url
+    assert gh.patch_data[0]["state"] == "closed"
 
 
 @pytest.mark.asyncio
@@ -79,35 +87,39 @@ async def test_installation_repositories_added():
     event = sansio.Event(data, event="installation_repositories", delivery_id="2")
 
     post = {
-        "url": "https://api.github.com/repos/dhruvmanila/testing/issues/8",
-        "number": 8,
-        "title": "Installation successful!",
-        "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
-        "state": "open",
-        "body": (
-            "This is the Algorithms bot at your service! "
-            "Thank you for installing me @dhruvmanila"
-        ),
+        f"/repos/{repository}/issues": {
+            "url": issue_url,
+            "number": number,
+            "title": "Installation successful!",
+            "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
+            "state": "open",
+            "body": (
+                "This is the Algorithms bot at your service! "
+                "Thank you for installing me @dhruvmanila"
+            ),
+        }
     }
     patch = {
-        "url": "https://api.github.com/repos/dhruvmanila/testing/issues/8",
-        "number": 8,
-        "title": "Installation successful!",
-        "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
-        "state": "closed",
-        "body": (
-            "This is the Algorithms bot at your service! "
-            "Thank you for installing me @dhruvmanila"
-        ),
+        issue_url: {
+            "url": issue_url,
+            "number": number,
+            "title": "Installation successful!",
+            "user": {"login": "algorithms-bot[bot]", "type": "Bot"},
+            "state": "closed",
+            "body": (
+                "This is the Algorithms bot at your service! "
+                "Thank you for installing me @dhruvmanila"
+            ),
+        }
     }
 
     gh = MockGitHubAPI(post=post, patch=patch)
     await installations.router.dispatch(event, gh)
-    assert gh.post_url == f"/repos/{repository}/issues"
-    assert gh.post_data["title"] == "Installation successful!"
-    assert gh.post_data["body"] == (
+    assert gh.post_url[0] == f"/repos/{repository}/issues"
+    assert gh.post_data[0]["title"] == "Installation successful!"
+    assert gh.post_data[0]["body"] == (
         "This is the Algorithms bot at your service! "
         "Thank you for installing me @dhruvmanila"
     )
-    assert gh.patch_url == "https://api.github.com/repos/dhruvmanila/testing/issues/8"
-    assert gh.patch_data["state"] == "closed"
+    assert gh.patch_url[0] == issue_url
+    assert gh.patch_data[0]["state"] == "closed"

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -12,18 +12,11 @@ number = 1
 issue_url = f"https://api.github.com/repos/{repository}/issues/{number}"
 
 
-def setup_module(module, monkeypatch=MonkeyPatch()):
-    """Monkeypatch for this module to store the MOCK_TOKEN in cache.
-
-    We cannot use `pytest.fixture(scope="module")` as `monkeypatch` fixture
-    only works at function level (this is a module level setup function),
-    so we will directly use the MonkeyPatch class where the fixture is
-    generated from and pass it as the default argument to this function.
-
-    This will only be executed once in this module, storing the token in the
-    cache for later use.
-    """
+@pytest.fixture(scope="module", autouse=True)
+def patch_module(monkeypatch=MonkeyPatch()):
     monkeypatch.setattr(apps, "get_installation_access_token", mock_return)
+    yield monkeypatch
+    monkeypatch.undo()
 
 
 @pytest.mark.asyncio

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+import pytest
+
+from algobot.constants import Label
+from algobot.parser import SEP, PullRequestFilesParser
+
+DATA_DIRPATH = Path.cwd() / "tests" / "data"
+
+FILE_EXPECTED = (
+    ("require_doctest.py", 4),
+    ("require_return_annotation.py", 3),
+    ("require_descriptive_names.py", 16),
+    ("require_annotations.py", 8),
+)
+
+
+# Don't mix this up with `utils.get_file_content`
+def get_file_code(filename: str) -> str:
+    with open(DATA_DIRPATH / filename) as file:
+        file_content = file.read()
+    return file_content
+
+
+def get_parser_total(parser: PullRequestFilesParser) -> int:
+    return (
+        len(parser._require_annotations)
+        + len(parser._require_descriptive_names)
+        + len(parser._require_doctest)
+        + len(parser._require_return_annotation)
+    )
+
+
+@pytest.mark.parametrize("filename, expected", FILE_EXPECTED)
+def test_individual_files(filename, expected):
+    code = get_file_code(filename)
+    parser = PullRequestFilesParser()
+    parser.parse_code(filename, code)
+    attr = filename.split(".")[0]
+    assert len(eval(f"parser._{attr}")) == expected
+
+
+def test_all_files():
+    parser = PullRequestFilesParser()
+    expected = 0
+    for filename, count in FILE_EXPECTED:
+        code = get_file_code(filename)
+        parser.parse_code(filename, code)
+        expected += count
+    assert get_parser_total(parser) == expected
+
+
+def test_skip_doctest():
+    filename = "require_doctest.py"
+    parser = PullRequestFilesParser()
+    assert parser.skip_doctest is False
+    parser.skip_doctest = True
+    assert parser.skip_doctest is True
+    code = get_file_code(filename)
+    parser.parse_code(filename, code)
+    assert get_parser_total(parser) == 0
+
+
+@pytest.mark.parametrize(
+    "cls_name, func_name, arg_name, expected",
+    (
+        (None, None, None, "`test.py`"),
+        ("TestClass", None, None, f"`test.py{SEP}TestClass`"),
+        (None, "test", None, f"`test.py{SEP}test`"),
+        (None, None, "num", f"`test.py{SEP}num`"),
+        ("TestClass", "func", None, f"`test.py{SEP}TestClass{SEP}func`"),
+        ("TestClass", None, "cls_var", f"`test.py{SEP}TestClass{SEP}cls_var`"),
+        (None, "func", "arg", f"`test.py{SEP}func{SEP}arg`"),
+        (
+            "TestClass",
+            "method",
+            "param",
+            f"`test.py{SEP}TestClass{SEP}method{SEP}param`",
+        ),
+    ),
+)
+def test_node_path(cls_name, func_name, arg_name, expected):
+    parser = PullRequestFilesParser()
+    parser._filename = "test.py"
+    assert (
+        parser._node_path(cls_name=cls_name, func_name=func_name, arg_name=arg_name)
+        == expected
+    )
+
+
+def test_add_all_labels():
+    parser = PullRequestFilesParser()
+    for filename, _ in FILE_EXPECTED:
+        code = get_file_code(filename)
+        parser.parse_code(filename, code)
+    add, remove = parser.labels_to_add_and_remove([])
+    assert add == [Label.REQUIRE_TEST, Label.DESCRIPTIVE_NAMES, Label.ANNOTATIONS]
+    assert remove == []
+
+
+def test_remove_all_labels():
+    parser = PullRequestFilesParser()
+    all_labels = [Label.REQUIRE_TEST, Label.DESCRIPTIVE_NAMES, Label.ANNOTATIONS]
+    add, remove = parser.labels_to_add_and_remove(all_labels)
+    assert add == []
+    assert remove == all_labels
+
+
+def test_add_few_labels():
+    parser = PullRequestFilesParser()
+    for i in range(2):
+        filename = FILE_EXPECTED[i][0]
+        code = get_file_code(filename)
+        parser.parse_code(filename, code)
+    assert get_parser_total(parser) == 7
+    add, remove = parser.labels_to_add_and_remove([Label.REQUIRE_TEST])
+    assert add == [Label.ANNOTATIONS]
+    assert remove == []
+
+
+def test_and_and_remove_labels():
+    parser = PullRequestFilesParser()
+    for i in range(1, 3):
+        filename = FILE_EXPECTED[i][0]
+        code = get_file_code(filename)
+        parser.parse_code(filename, code)
+    assert get_parser_total(parser) == 19
+    add, remove = parser.labels_to_add_and_remove([Label.REQUIRE_TEST])
+    assert add == [Label.DESCRIPTIVE_NAMES, Label.ANNOTATIONS]
+    assert remove == [Label.REQUIRE_TEST]

--- a/tests/test_pull_requests.py
+++ b/tests/test_pull_requests.py
@@ -1,0 +1,485 @@
+import urllib.parse
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from gidgethub import apps, sansio
+
+from algobot import pull_requests, utils
+from algobot.constants import Label
+from algobot.pull_requests import (
+    CHECKBOX_NOT_TICKED_COMMENT,
+    EMPTY_BODY_COMMENT,
+    MAX_PR_REACHED_COMMENT,
+    NO_EXTENSION_COMMENT,
+)
+
+from .test_parser import get_file_code
+from .utils import MOCK_INSTALLATION_ID, MockGitHubAPI, mock_return
+
+# Common constants
+number = 1
+user = "test"
+repository = "TheAlgorithms/Python"
+sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
+comment = "This is a comment"
+
+# Incomplete urls
+search_url = f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}"
+pr_search_url = f"/search/issues?q=type:pr+state:open+repo:{repository}"
+pr_user_search_url = (
+    f"/search/issues?q=type:pr+state:open+repo:{repository}+author:{user}"
+)
+
+# Complete urls
+html_pr_url = f"https://github.com/{repository}/pulls/{number}"
+pr_url = f"https://api.github.com/repos/{repository}/pulls/{number}"
+issue_url = f"https://api.github.com/repos/{repository}/issues/{number}"
+labels_url = issue_url + "/labels"
+comments_url = issue_url + "/comments"
+reviewers_url = pr_url + "/requested_reviewers"
+files_url = pr_url + "/files"
+
+# PR template ticked
+CHECKBOX_TICKED = (
+    "### **Describe your change:**\r\n\r\n\r\n\r\n* [ ] Add an algorithm?\r\n* [x]"
+    " Fix a bug or typo in an existing algorithm?\r\n* [x] Documentation change?"
+    "\r\n\r\n### **Checklist:**\r\n* [x] I have read [CONTRIBUTING.md]"
+    "(https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).\r\n* "
+    "[x] This pull request is all my own work -- I have not plagiarized.\r\n* [x] "
+    "I know that pull requests will not be merged if they fail the automated tests."
+    "\r\n* [x] This PR only changes one algorithm file.  To ease review, please open "
+    "separate PRs for separate algorithms.\r\n* [x] All new Python files are placed "
+    "inside an existing directory.\r\n* [x] All filenames are in all lowercase "
+    "characters with no spaces or dashes.\r\n* [x] All functions and variable names "
+    "follow Python naming conventions.\r\n* [x] All function parameters and return "
+    "values are annotated with Python [type hints]"
+    "(https://docs.python.org/3/library/typing.html).\r\n* [x] All functions have "
+    "[doctests](https://docs.python.org/3/library/doctest.html) that pass the "
+    "automated testing.\r\n* [x] All new algorithms have a URL in its comments that "
+    "points to Wikipedia or other similar explanation.\r\n* [ ] If this pull request "
+    "resolves one or more open issues then the commit message contains "
+    "`Fixes: #{$ISSUE_NO}`.\r\n"
+)
+
+# PR template not ticked
+CHECKBOX_NOT_TICKED = (
+    "### **Describe your change:**\r\n\r\n\r\n\r\n* [ ] Add an algorithm?\r\n* [ ]"
+    " Fix a bug or typo in an existing algorithm?\r\n* [ ] Documentation change?"
+    "\r\n\r\n### **Checklist:**\r\n* [ ] I have read [CONTRIBUTING.md]"
+    "(https://github.com/TheAlgorithms/Python/blob/master/CONTRIBUTING.md).\r\n* "
+    "[ ] This pull request is all my own work -- I have not plagiarized.\r\n* [ ] "
+    "I know that pull requests will not be merged if they fail the automated tests."
+    "\r\n* [ ] This PR only changes one algorithm file.  To ease review, please open "
+    "separate PRs for separate algorithms.\r\n* [ ] All new Python files are placed "
+    "inside an existing directory.\r\n* [ ] All filenames are in all lowercase "
+    "characters with no spaces or dashes.\r\n* [ ] All functions and variable names "
+    "follow Python naming conventions.\r\n* [ ] All function parameters and return "
+    "values are annotated with Python [type hints]"
+    "(https://docs.python.org/3/library/typing.html).\r\n* [ ] All functions have "
+    "[doctests](https://docs.python.org/3/library/doctest.html) that pass the "
+    "automated testing.\r\n* [ ] All new algorithms have a URL in its comments that "
+    "points to Wikipedia or other similar explanation.\r\n* [ ] If this pull request "
+    "resolves one or more open issues then the commit message contains "
+    "`Fixes: #{$ISSUE_NO}`.\r\n"
+)
+
+# Comment constants
+EMPTY_BODY_COMMENT = EMPTY_BODY_COMMENT.format(user_login=user)
+CHECKBOX_NOT_TICKED_COMMENT = CHECKBOX_NOT_TICKED_COMMENT.format(user_login=user)
+NO_EXTENSION_COMMENT = NO_EXTENSION_COMMENT.format(user_login=user)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def patch_module(monkeypatch=MonkeyPatch()):
+    async def mock_get_file_content(gh, installation_id, file):
+        if file["filename"] in {
+            "require_doctest.py",
+            "require_annotations.py",
+            "require_descriptive_names.py",
+            "require_return_annotation.py",
+        }:
+            return get_file_code(file["filename"])
+        else:
+            return ""
+
+    monkeypatch.setattr(apps, "get_installation_access_token", mock_return)
+    monkeypatch.setattr(utils, "get_file_content", mock_get_file_content)
+    yield monkeypatch
+    monkeypatch.undo()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body, comment",
+    (
+        ("", EMPTY_BODY_COMMENT),
+        (CHECKBOX_NOT_TICKED, CHECKBOX_NOT_TICKED_COMMENT),
+    ),
+)
+async def test_pr_opened_no_body_and_no_ticked(body, comment):
+    data = {
+        "action": "opened",
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": body,
+            "labels": [],
+            "user": {"login": user},
+            "author_association": "NONE",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    getiter = {files_url: []}
+    post = {labels_url: {}, comments_url: {}}
+    patch = {pr_url: {}}
+    delete = {reviewers_url: {}}
+    gh = MockGitHubAPI(getiter=getiter, post=post, patch=patch, delete=delete)
+    await pull_requests.router.dispatch(event, gh)
+    assert gh.getiter_url[0] == files_url
+    assert len(gh.post_url) == 2
+    assert gh.post_url == [comments_url, labels_url]
+    assert gh.post_data[0] == {"body": comment}
+    assert gh.post_data[1] == {"labels": ["invalid"]}
+    assert gh.patch_url[0] == pr_url
+    assert gh.patch_data[0] == {"state": "closed"}
+    assert gh.delete_url[0] == reviewers_url
+    assert gh.delete_data[0] == {"reviewers": ["test1", "test2"]}
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_by_member():
+    data = {
+        "action": "opened",
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": "",  # body can be empty for member
+            "labels": [],
+            "user": {"login": user},
+            "author_association": "MEMBER",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "html_url": html_pr_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    getiter = {files_url: []}  # for check_pr_files function
+    gh = MockGitHubAPI(getiter=getiter)
+    await pull_requests.router.dispatch(event, gh)
+    assert gh.getiter_url[0] == files_url
+    assert gh.post_url == []
+    assert gh.post_data == []
+    assert gh.patch_url == []
+    assert gh.patch_data == []
+    assert gh.delete_url == []
+    assert gh.delete_data == []
+
+
+@pytest.mark.asyncio
+async def test_max_pr_reached():
+    data = {
+        "action": "opened",
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": CHECKBOX_TICKED,
+            "labels": [],
+            "user": {"login": user},
+            "author_association": "NONE",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "html_url": html_pr_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    getiter = {
+        pr_user_search_url: {
+            "total_count": 2,
+            "items": [
+                {"number": 1, "state": "opened"},
+                {"number": 2, "state": "opened"},
+            ],
+        },
+        files_url: [],  # for check_pr_files function
+    }
+    post = {comments_url: {}}
+    patch = {pr_url: {}}
+    delete = {reviewers_url: {}}
+    gh = MockGitHubAPI(getiter=getiter, post=post, patch=patch, delete=delete)
+    await pull_requests.router.dispatch(event, gh)
+    assert gh.getiter_url[0] == pr_user_search_url
+    assert gh.post_url[0] == comments_url
+    assert gh.post_data[0] == {
+        "body": MAX_PR_REACHED_COMMENT.format(user_login=user, pr_number="#1, #2")
+    }
+    assert gh.patch_url[0] == pr_url
+    assert gh.delete_url[0] == reviewers_url
+    assert gh.delete_data[0] == {"reviewers": ["test1", "test2"]}
+
+
+@pytest.mark.asyncio
+async def test_max_pr_disabled(monkeypatch):
+    monkeypatch.setattr(pull_requests, "MAX_PR_PER_USER", 0)
+    data = {
+        "action": "opened",
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": CHECKBOX_TICKED,
+            "labels": [],
+            "user": {"login": user},
+            "author_association": "NONE",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "html_url": html_pr_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    getiter = {files_url: []}
+    gh = MockGitHubAPI(getiter=getiter)
+    await pull_requests.router.dispatch(event, gh)
+    assert gh.getiter_url[0] == files_url
+    # No changes as max pr checks are disabled
+    assert gh.post_url == []
+    assert gh.post_data == []
+    assert gh.patch_url == []
+    assert gh.delete_url == []
+    assert gh.delete_data == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action, getiter",
+    (
+        (
+            "opened",
+            {
+                pr_user_search_url: {
+                    "total_count": 1,
+                    "items": [
+                        {"number": 1, "state": "opened"},
+                    ],
+                },
+                files_url: [
+                    {"filename": "newton.py", "contents_url": ""},
+                    {"filename": "fibonacci", "contents_url": ""},
+                ],
+            },
+        ),
+        (
+            "synchronize",
+            {
+                files_url: [
+                    {"filename": "newton.py", "contents_url": ""},
+                    {"filename": "fibonacci", "contents_url": ""},
+                ],
+            },
+        ),
+    ),
+)
+async def test_for_extensionless_files_on_opened(action, getiter):
+    data = {
+        "action": action,
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": CHECKBOX_TICKED,
+            "labels": [],
+            "user": {"login": user},
+            "author_association": "NONE",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "html_url": html_pr_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    post = {comments_url: {}, labels_url: {}}
+    patch = {pr_url: {}}
+    delete = {reviewers_url: {}}
+    gh = MockGitHubAPI(getiter=getiter, post=post, patch=patch, delete=delete)
+    await pull_requests.router.dispatch(event, gh)
+    if event.data["action"] == "opened":
+        assert len(gh.getiter_url) == 2
+        assert gh.getiter_url == [pr_user_search_url, files_url]
+    elif event.data["action"] == "synchronize":
+        assert len(gh.getiter_url) == 1
+        assert gh.getiter_url[0] == files_url
+    assert len(gh.post_url) == 2
+    assert gh.post_url == [comments_url, labels_url]
+    assert gh.post_data[0] == {"body": NO_EXTENSION_COMMENT}
+    assert gh.post_data[1] == {"labels": ["invalid"]}
+    assert gh.patch_url[0] == pr_url
+    assert gh.patch_data[0] == {"state": "closed"}
+    assert gh.delete_url[0] == reviewers_url
+    assert gh.delete_data[0] == {"reviewers": ["test1", "test2"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action, getiter",
+    (
+        (
+            "opened",
+            {
+                pr_user_search_url: {
+                    "total_count": 1,
+                    "items": [
+                        {"number": 1, "state": "opened"},
+                    ],
+                },
+                files_url: [
+                    {"filename": ".travis.yml", "contents_url": ""},
+                    {"filename": "README.md", "contents_url": ""},
+                    {"filename": "pytest.ini", "contents_url": ""},
+                ],
+            },
+        ),
+        (
+            "synchronize",
+            {
+                files_url: [
+                    {"filename": ".travis.yml", "contents_url": ""},
+                    {"filename": "README.md", "contents_url": ""},
+                    {"filename": "__init__.py", "contents_url": ""},
+                ],  # We will add one `__` Python file in the mix
+            },
+        ),
+    ),
+)
+async def test_pr_with_no_python_files(action, getiter):
+    data = {
+        "action": action,
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": CHECKBOX_TICKED,
+            "labels": [],
+            "user": {"login": user},
+            "author_association": "NONE",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "html_url": html_pr_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    gh = MockGitHubAPI(getiter=getiter)
+    await pull_requests.router.dispatch(event, gh)
+    if data["action"] == "opened":
+        assert len(gh.getiter_url) == 2
+        assert gh.getiter_url == [pr_user_search_url, files_url]
+    elif data["action"] == "synchronize":
+        assert len(gh.getiter_url) == 1
+        assert gh.getiter_url == [files_url]
+    # Nothing happens as there are no Python files
+    assert gh.post_url == []
+    assert gh.post_data == []
+    assert gh.patch_url == []
+    assert gh.patch_data == []
+    assert gh.delete_url == []
+    assert gh.delete_data == []
+
+
+# From this point on, as we have tested the `PullRequestFilesParser` in a separate
+# file we will assume that the logic is correct for the class. With that in mind,
+# we will only test the logic of the `check_pr_files` function and not whether the
+# parser is working accordingly or not.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action, getiter",
+    (
+        (
+            "opened",
+            {
+                pr_user_search_url: {
+                    "total_count": 1,
+                    "items": [
+                        {"number": 1, "state": "opened"},
+                    ],
+                },
+                files_url: [
+                    {"filename": "require_doctest.py", "contents_url": ""},
+                    {"filename": "test_algo.py", "contents_url": ""},
+                    {"filename": "require_annotations.py", "contents_url": ""},
+                ],
+            },
+        ),
+        (
+            "synchronize",
+            {
+                files_url: [
+                    {"filename": "require_doctest.py", "contents_url": ""},
+                    {"filename": "test_algo.py", "contents_url": ""},
+                    {"filename": "require_annotations.py", "contents_url": ""},
+                ],
+            },
+        ),
+    ),
+)
+async def test_pr_with_test_file(action, getiter):
+    remove_label = urllib.parse.quote(Label.REQUIRE_TEST)
+    data = {
+        "action": action,
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "url": pr_url,
+            "body": CHECKBOX_TICKED,
+            # This is like a marker to test the function, the label should be removed
+            "labels": [{"name": Label.REQUIRE_TEST}],
+            "user": {"login": user},
+            "author_association": "NONE",
+            "comments_url": comments_url,
+            "issue_url": issue_url,
+            "html_url": html_pr_url,
+            "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+        },
+        "repository": {"full_name": repository},
+        "installation": {"id": MOCK_INSTALLATION_ID},
+    }
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
+    post = {labels_url: {}, comments_url: {}}
+    delete = {labels_url + f"/{remove_label}": {}}
+    gh = MockGitHubAPI(getiter=getiter, post=post, delete=delete)
+    await pull_requests.router.dispatch(event, gh)
+    if data["action"] == "opened":
+        assert len(gh.getiter_url) == 2
+        assert gh.getiter_url == [pr_user_search_url, files_url]
+        assert len(gh.post_url) == 2
+        assert gh.post_url == [labels_url, comments_url]
+    elif data["action"] == "synchronize":
+        assert len(gh.getiter_url) == 1
+        assert gh.getiter_url[0] == files_url
+        assert len(gh.post_url) == 1
+        # No comment is posted in `synchronize`
+        assert gh.post_url == [labels_url]
+    assert gh.post_data[0] == {"labels": [Label.ANNOTATIONS]}
+    assert gh.delete_url[0] == labels_url + f"/{remove_label}"
+    assert gh.delete_data == [{}]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,7 @@ async def test_get_access_token(monkeypatch):
     monkeypatch.setattr(apps, "get_installation_access_token", mock_return)
     token = await utils.get_access_token(gh, MOCK_INSTALLATION_ID)
     assert token == MOCK_TOKEN
+    monkeypatch.undo()
 
 
 @pytest.mark.asyncio
@@ -50,6 +51,7 @@ async def test_get_cached_access_token(monkeypatch):
     monkeypatch.delattr(apps, "get_installation_access_token")
     token = await utils.get_access_token(gh, MOCK_INSTALLATION_ID)
     assert token == MOCK_TOKEN
+    monkeypatch.undo()
 
 
 @pytest.mark.asyncio
@@ -417,7 +419,9 @@ async def test_get_file_content():
     )
     gh = MockGitHubAPI(getitem=getitem)
     result = await utils.get_file_content(
-        gh, MOCK_INSTALLATION_ID, file={"contents_url": contents_url1}
+        gh,
+        MOCK_INSTALLATION_ID,
+        file={"filename": "test.py", "contents_url": contents_url1},
     )
     assert result == output
     assert gh.getitem_url[0] == contents_url1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,31 @@ from algobot.constants import Label
 
 from .utils import MOCK_INSTALLATION_ID, MOCK_TOKEN, MockGitHubAPI, mock_return
 
+# Common test constants
+user = "test"
+number = 1
+sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
+repository = "TheAlgorithms/Python"
+comment = "This is a test comment"
+
+# Incomplete urls
+search_url = f"/search/issues?q=type:pr+repo:{repository}+sha:{sha}"
+pr_search_url = f"/search/issues?q=type:pr+state:open+repo:{repository}"
+pr_user_search_url = (
+    f"/search/issues?q=type:pr+state:open+repo:{repository}+author:{user}"
+)
+check_run_url = f"/repos/{repository}/commits/{sha}/check-runs"
+
+# Complete urls
+pr_url = f"https://api.github.com/repos/{repository}/pulls/{number}"
+issue_url = f"https://api.github.com/repos/{repository}/issues/{number}"
+labels_url = issue_url + "/labels"
+comments_url = issue_url + "/comments"
+reviewers_url = pr_url + "/requested_reviewers"
+files_url = pr_url + "/files"
+contents_url1 = f"https://api.github.com/repos/{repository}/contents/test1.py?ref={sha}"
+contents_url2 = f"https://api.github.com/repos/{repository}/contents/test2.py?ref={sha}"
+
 
 @pytest.mark.asyncio
 async def test_get_access_token(monkeypatch):
@@ -29,16 +54,13 @@ async def test_get_cached_access_token(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_issue_for_commit():
-    sha = "a06212064d8e1c349c75c5ea4568ecf155368c21"
-    repository = "TheAlgorithms/Python"
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 1,
             "incomplete_results": False,
             "items": [
                 {
-                    "number": 3378,
-                    "title": "Create GitHub action only for Project Euler",
+                    "number": number,
                     "state": "open",
                 }
             ],
@@ -48,21 +70,15 @@ async def test_get_issue_for_commit():
     result = await utils.get_issue_for_commit(
         gh, MOCK_INSTALLATION_ID, sha=sha, repository=repository
     )
-    assert (
-        gh.getitem_url
-        == f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}"
-    )
-    assert result["number"] == 3378
-    assert result["title"] == "Create GitHub action only for Project Euler"
+    assert gh.getitem_url[0] == search_url
+    assert result["number"] == number
     assert result["state"] == "open"
 
 
 @pytest.mark.asyncio
 async def test_get_issue_for_commit_not_found():
-    sha = "1854eeaf24aa3d4eada256b6223d8d4ed05f63a1"
-    repository = "TheAlgorithms/Python"
     getitem = {
-        f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}": {
+        search_url: {
             "total_count": 0,
             "incomplete_results": False,
             "items": [],
@@ -72,22 +88,21 @@ async def test_get_issue_for_commit_not_found():
     result = await utils.get_issue_for_commit(
         gh, MOCK_INSTALLATION_ID, sha=sha, repository=repository
     )
-    assert (
-        gh.getitem_url
-        == f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}"
-    )
+    assert gh.getitem_url[0] == search_url
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_get_check_runs_for_commit():
-    sha = "920a347a8fdbe9a58ea35b81c54b4c8b877114c5"
-    repository = "TheAlgorithms/Python"
     getitem = {
-        f"/repos/{repository}/commits/{sha}/check-runs": {
+        check_run_url: {
             "total_count": 4,
             "check_runs": [
-                {"status": "completed", "conclusion": "success", "name": "build"},
+                {
+                    "status": "completed",
+                    "conclusion": "success",
+                    "name": "build",
+                },
                 {
                     "status": "completed",
                     "conclusion": "failure",
@@ -110,7 +125,7 @@ async def test_get_check_runs_for_commit():
     result = await utils.get_check_runs_for_commit(
         gh, MOCK_INSTALLATION_ID, sha=sha, repository=repository
     )
-    assert gh.getitem_url == f"/repos/{repository}/commits/{sha}/check-runs"
+    assert gh.getitem_url[0] == check_run_url
     assert result["total_count"] == 4
     assert [check_run["conclusion"] for check_run in result["check_runs"]] == [
         "success",
@@ -122,48 +137,287 @@ async def test_get_check_runs_for_commit():
 
 
 @pytest.mark.asyncio
-async def test_add_label_to_pr_or_issue():
-    repository = "TheAlgorithms/Python"
-    pull_request = {
-        "number": 2526,
-        "issue_url": f"https://api.github.com/repos/{repository}/issues/2526",
+@pytest.mark.parametrize(
+    "pr_or_issue",
+    [
+        {"number": number, "issue_url": issue_url},
+        {"number": number, "labels_url": labels_url},
+    ],
+)
+async def test_add_label_to_pr_or_issue(pr_or_issue):
+    post = {
+        labels_url: [
+            {"name": Label.ANNOTATIONS},
+            {"name": Label.FAILED_TEST},
+        ]
     }
-    post = [
-        {"name": "Require: Tests", "color": "fbca04"},
-        {"name": "Require: Type hints", "color": "fbca04"},
-        {"name": Label.FAILED_TEST, "color": "d93f0b"},
-        {"name": "Status: awaiting changes", "color": "7ae8b3"},
-    ]
     gh = MockGitHubAPI(post=post)
     result = await utils.add_label_to_pr_or_issue(
-        gh, MOCK_INSTALLATION_ID, label=Label.FAILED_TEST, pr_or_issue=pull_request
+        gh, MOCK_INSTALLATION_ID, label=Label.FAILED_TEST, pr_or_issue=pr_or_issue
     )
-    assert (
-        gh.post_url == f"https://api.github.com/repos/{repository}/issues/2526/labels"
-    )
-    assert gh.post_data == {"labels": [Label.FAILED_TEST]}
+    assert gh.post_url[0] == labels_url
+    assert gh.post_data[0] == {"labels": [Label.FAILED_TEST]}
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_remove_label_from_pr_or_issue():
-    parse_label = urllib.parse.quote(Label.FAILED_TEST)
-    repository = "TheAlgorithms/Python"
-    pull_request = {
-        "number": 2526,
-        "issue_url": f"https://api.github.com/repos/{repository}/issues/2526",
+async def test_add_multiple_labels():
+    pr_or_issue = {"number": number, "issue_url": issue_url}
+    post = {
+        labels_url: [
+            {"name": Label.ANNOTATIONS},
+            {"name": Label.FAILED_TEST},
+        ]
     }
-    delete = [
-        {"name": "Require: Tests", "color": "fbca04"},
-        {"name": "Require: Type hints", "color": "fbca04"},
-        {"name": "Status: awaiting changes", "color": "7ae8b3"},
-    ]
+    gh = MockGitHubAPI(post=post)
+    result = await utils.add_label_to_pr_or_issue(
+        gh,
+        MOCK_INSTALLATION_ID,
+        label=[Label.ANNOTATIONS, Label.AWAITING_REVIEW],
+        pr_or_issue=pr_or_issue,
+    )
+    assert gh.post_url[0] == labels_url
+    assert gh.post_data[0] == {"labels": [Label.ANNOTATIONS, Label.AWAITING_REVIEW]}
+    assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pr_or_issue",
+    [
+        {"number": number, "issue_url": issue_url},
+        {"number": number, "labels_url": labels_url},
+    ],
+)
+async def test_remove_label_from_pr(pr_or_issue):
+    parse_label = urllib.parse.quote(Label.FAILED_TEST)
+    delete = {labels_url + f"/{parse_label}": [{"name": Label.ANNOTATIONS}]}
     gh = MockGitHubAPI(delete=delete)
     result = await utils.remove_label_from_pr_or_issue(
-        gh, MOCK_INSTALLATION_ID, label=Label.FAILED_TEST, pr_or_issue=pull_request
+        gh, MOCK_INSTALLATION_ID, label=Label.FAILED_TEST, pr_or_issue=pr_or_issue
     )
-    assert (
-        gh.delete_url
-        == f"https://api.github.com/repos/{repository}/issues/2526/labels/{parse_label}"
-    )
+    assert gh.delete_url[0] == labels_url + f"/{parse_label}"
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_remove_multiple_labels():
+    parse_label1 = urllib.parse.quote(Label.ANNOTATIONS)
+    parse_label2 = urllib.parse.quote(Label.AWAITING_REVIEW)
+    pr_or_issue = {"number": number, "issue_url": issue_url}
+    delete = {
+        labels_url + f"/{parse_label1}": [],
+        labels_url + f"/{parse_label2}": [],
+    }
+    gh = MockGitHubAPI(delete=delete)
+    result = await utils.remove_label_from_pr_or_issue(
+        gh,
+        MOCK_INSTALLATION_ID,
+        label=[Label.ANNOTATIONS, Label.AWAITING_REVIEW],
+        pr_or_issue=pr_or_issue,
+    )
+    assert gh.delete_url[0] == labels_url + f"/{parse_label1}"
+    assert gh.delete_url[1] == labels_url + f"/{parse_label2}"
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_total_open_prs_for_repo():
+    getitem = {pr_search_url: {"total_count": 10, "items": []}}
+    gh = MockGitHubAPI(getitem=getitem)
+    result = await utils.get_total_open_prs(
+        gh, MOCK_INSTALLATION_ID, repository=repository
+    )
+    assert result == 10
+    assert gh.getitem_url[0] == pr_search_url
+
+
+@pytest.mark.asyncio
+async def test_get_total_open_prs_for_user():
+    getitem = {pr_user_search_url: {"total_count": 10, "items": []}}
+    gh = MockGitHubAPI(getitem=getitem)
+    result = await utils.get_total_open_prs(
+        gh, MOCK_INSTALLATION_ID, repository=repository, user_login=user
+    )
+    assert result == 10
+    assert gh.getitem_url[0] == pr_user_search_url
+
+
+@pytest.mark.asyncio
+async def test_get_total_open_pr_numbers_for_repo():
+    getiter = {
+        pr_search_url: {
+            "total_count": 3,
+            "items": [{"number": 1}, {"number": 2}, {"number": 3}],
+        }
+    }
+    gh = MockGitHubAPI(getiter=getiter)
+    result = await utils.get_total_open_prs(
+        gh, MOCK_INSTALLATION_ID, repository=repository, count=False
+    )
+    assert result == [1, 2, 3]
+    assert gh.getiter_url[0] == pr_search_url
+
+
+@pytest.mark.asyncio
+async def test_get_total_open_pr_numbers_for_user():
+    getiter = {
+        pr_user_search_url: {
+            "total_count": 3,
+            "items": [{"number": 1}, {"number": 2}, {"number": 3}],
+        }
+    }
+    gh = MockGitHubAPI(getiter=getiter)
+    result = await utils.get_total_open_prs(
+        gh, MOCK_INSTALLATION_ID, repository=repository, user_login=user, count=False
+    )
+    assert result == [1, 2, 3]
+    assert gh.getiter_url[0] == pr_user_search_url
+
+
+@pytest.mark.asyncio
+async def test_add_comment_to_pr_or_issue():
+    # PR and issue both have `comments_url` key
+    pr_or_issue = {"number": number, "comments_url": comments_url}
+    post = {comments_url: {}}
+    gh = MockGitHubAPI(post=post)
+    result = await utils.add_comment_to_pr_or_issue(
+        gh, MOCK_INSTALLATION_ID, comment=comment, pr_or_issue=pr_or_issue
+    )
+    assert gh.post_url[0] == comments_url
+    assert gh.post_data[0] == {"body": comment}
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_close_pr_no_reviewers():
+    pull_request = {
+        "url": pr_url,
+        "comments_url": comments_url,
+        "requested_reviewers": [],
+    }
+    post = {comments_url: {}}
+    patch = {pr_url: {}}
+    gh = MockGitHubAPI(post=post, patch=patch)
+    result = await utils.close_pr_or_issue(
+        gh, MOCK_INSTALLATION_ID, comment=comment, pr_or_issue=pull_request
+    )
+    assert gh.post_url[0] == comments_url
+    assert gh.post_data[0] == {"body": comment}
+    assert gh.patch_url[0] == pr_url
+    assert gh.patch_data[0] == {"state": "closed"}
+    assert gh.delete_url == []  # no reviewers to delete
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_close_pr_with_reviewers():
+    pull_request = {
+        "url": pr_url,
+        "comments_url": comments_url,
+        "requested_reviewers": [{"login": "test1"}, {"login": "test2"}],
+    }
+    post = {comments_url: {}}
+    patch = {pr_url: {}}
+    delete = {reviewers_url: {}}
+    gh = MockGitHubAPI(post=post, patch=patch, delete=delete)
+    result = await utils.close_pr_or_issue(
+        gh, MOCK_INSTALLATION_ID, comment=comment, pr_or_issue=pull_request
+    )
+    assert gh.post_url[0] == comments_url
+    assert gh.post_data[0] == {"body": comment}
+    assert gh.patch_url[0] == pr_url
+    assert gh.patch_data[0] == {"state": "closed"}
+    assert gh.delete_url[0] == reviewers_url
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_close_issue():
+    # issues don't have `requested_reviewers` field
+    issue = {"url": issue_url, "comments_url": comments_url}
+    post = {comments_url: {}}
+    patch = {issue_url: {}}
+    gh = MockGitHubAPI(post=post, patch=patch)
+    result = await utils.close_pr_or_issue(
+        gh, MOCK_INSTALLATION_ID, comment=comment, pr_or_issue=issue
+    )
+    assert gh.post_url[0] == comments_url
+    assert gh.post_data[0] == {"body": comment}
+    assert gh.patch_url[0] == issue_url
+    assert gh.patch_data[0] == {"state": "closed"}
+    assert gh.delete_url == []
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_close_pr_or_issue_with_label():
+    # PRs don't have `labels_url` attribute
+    pull_request = {
+        "url": pr_url,
+        "comments_url": comments_url,
+        "issue_url": issue_url,
+        "requested_reviewers": [],
+    }
+    post = {comments_url: {}, labels_url: {}}
+    patch = {pr_url: {}}
+    gh = MockGitHubAPI(post=post, patch=patch)
+    result = await utils.close_pr_or_issue(
+        gh,
+        MOCK_INSTALLATION_ID,
+        comment=comment,
+        pr_or_issue=pull_request,
+        label="invalid",
+    )
+    assert gh.post_url[0] == comments_url
+    assert gh.post_data[0] == {"body": comment}
+    assert gh.post_url[1] == labels_url
+    assert gh.post_data[1] == {"labels": ["invalid"]}
+    assert gh.patch_url[0] == pr_url
+    assert gh.patch_data[0] == {"state": "closed"}
+    assert gh.delete_url == []
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_pr_files():
+    files = [
+        {"filename": "test1.py", "contents_url": contents_url1},
+        {"filename": "test2.py", "contents_url": contents_url2},
+    ]
+    getiter = {files_url: files}
+    pull_request = {"url": pr_url}
+    gh = MockGitHubAPI(getiter=getiter)
+    result = await utils.get_pr_files(
+        gh, MOCK_INSTALLATION_ID, pull_request=pull_request
+    )
+    assert result == files
+    assert gh.getiter_url[0] == files_url
+
+
+@pytest.mark.asyncio
+async def test_get_file_content():
+    getitem = {
+        contents_url1: {
+            "content": (
+                "ZGVmIHRlc3QxKGEsIGIsIGMpOgoJIiIiCglBIHRlc3QgZnVuY3Rpb24KCSI"
+                "i\nIgoJcmV0dXJuIEZhbHNlCgpkZWYgdGVzdDIoZCwgZSwgZik6CgkiIiIKC"
+                "UEg\ndGVzdCBmdW5jdGlvbgoJIiIiCglyZXR1cm4gTm9uZQoKZGVmIHRlc3Q"
+                "zKGE6\nIGludCkgLT4gTm9uZToKCSIiIgoJPj4+IGZpbmRJc2xhbmRzKDEsID"
+                "EsIDEp\nCgkiIiIKCXJldHVybiBOb25lCgppZiBfX25hbWVfXyA9PSAnX19tY"
+                "WluX18n\nOgoJcGFzcwo=\n"
+            )
+        }
+    }
+    output = (
+        b'def test1(a, b, c):\n\t"""\n\tA test function\n\t"""\n\treturn False'
+        b'\n\ndef test2(d, e, f):\n\t"""\n\tA test function\n\t"""\n\treturn None'
+        b'\n\ndef test3(a: int) -> None:\n\t"""\n\t>>> findIslands(1, 1, 1)\n\t"""'
+        b"\n\treturn None\n\nif __name__ == '__main__':\n\tpass\n"
+    )
+    gh = MockGitHubAPI(getitem=getitem)
+    result = await utils.get_file_content(
+        gh, MOCK_INSTALLATION_ID, file={"contents_url": contents_url1}
+    )
+    assert result == output
+    assert gh.getitem_url[0] == contents_url1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ repository = "TheAlgorithms/Python"
 comment = "This is a test comment"
 
 # Incomplete urls
-search_url = f"/search/issues?q=type:pr+repo:{repository}+sha:{sha}"
+search_url = f"/search/issues?q=type:pr+state:open+repo:{repository}+sha:{sha}"
 pr_search_url = f"/search/issues?q=type:pr+state:open+repo:{repository}"
 pr_user_search_url = (
     f"/search/issues?q=type:pr+state:open+repo:{repository}+author:{user}"
@@ -67,7 +67,7 @@ async def test_get_issue_for_commit():
         }
     }
     gh = MockGitHubAPI(getitem=getitem)
-    result = await utils.get_issue_for_commit(
+    result = await utils.get_pr_for_commit(
         gh, MOCK_INSTALLATION_ID, sha=sha, repository=repository
     )
     assert gh.getitem_url[0] == search_url
@@ -85,7 +85,7 @@ async def test_get_issue_for_commit_not_found():
         }
     }
     gh = MockGitHubAPI(getitem=getitem)
-    result = await utils.get_issue_for_commit(
+    result = await utils.get_pr_for_commit(
         gh, MOCK_INSTALLATION_ID, sha=sha, repository=repository
     )
     assert gh.getitem_url[0] == search_url

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,11 @@
+from typing import Any, List, Optional, Dict
 from gidgethub import sansio
 
 MOCK_TOKEN = 19
 MOCK_INSTALLATION_ID = 1234
 
 
-async def mock_return(*args, **kwargs):
+async def mock_return(*args, **kwargs) -> Dict[str, Any]:
     return {"token": MOCK_TOKEN}
 
 
@@ -12,12 +13,12 @@ class MockGitHubAPI:
     def __init__(
         self,
         *,
-        getitem=None,
-        getiter=None,
-        post=None,
-        patch=None,
-        put=None,
-        delete=None
+        getitem: Optional[Dict[str, Any]] = None,
+        getiter: Optional[Dict[str, Any]] = None,
+        post: Optional[Dict[str, Any]] = None,
+        patch: Optional[Dict[str, Any]] = None,
+        put: Optional[Dict[str, Any]] = None,
+        delete: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._getitem_return = getitem
         self._getiter_return = getiter
@@ -25,43 +26,40 @@ class MockGitHubAPI:
         self._patch_return = patch
         self._put_return = put
         self._delete_return = delete
-        self.getitem_url = None
-        self.getiter_url = None
-        self.post_url = self.post_data = None
-        self.patch_url = self.patch_data = None
-        self.put_url = self.put_data = None
-        self.delete_url = None
+        self.getitem_url: List[str] = []
+        self.getiter_url: List[str] = []
+        self.post_url: List[str] = []
+        self.post_data: List[str] = []
+        self.patch_url: List[str] = []
+        self.patch_data: List[str] = []
+        self.delete_url: List[str] = []
 
     async def getitem(self, url, *, accept=sansio.accept_format(), oauth_token=None):
-        self.getitem_url = url
+        self.getitem_url.append(url)
         return self._getitem_return[url]
 
     async def getiter(self, url, *, accept=sansio.accept_format(), oauth_token=None):
-        self.getiter_url = url
-        for item in self._getiter_return[url]:
+        self.getiter_url.append(url)
+        data = self._getiter_return[url]
+        if isinstance(data, dict) and "items" in data:
+            data = data["items"]
+        for item in data:
             yield item
 
     async def post(self, url, *, data, accept=sansio.accept_format(), oauth_token=None):
-        self.post_url = url
-        self.post_data = data
-        return self._post_return
+        self.post_url.append(url)
+        self.post_data.append(data)
+        return self._post_return[url]
 
     async def patch(
         self, url, *, data, accept=sansio.accept_format(), oauth_token=None
     ):
-        self.patch_url = url
-        self.patch_data = data
-        return self._patch_return
-
-    async def put(
-        self, url, *, data=b"", accept=sansio.accept_format(), oauth_token=None
-    ):
-        self.put_url = url
-        self.put_data = data
-        return self._put_return
+        self.patch_url.append(url)
+        self.patch_data.append(data)
+        return self._patch_return[url]
 
     async def delete(
         self, url, *, data=b"", accept=sansio.accept_format(), oauth_token=None
     ):
-        self.delete_url = url
-        return self._delete_return
+        self.delete_url.append(url)
+        return self._delete_return[url]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
+
 from gidgethub import sansio
 
 MOCK_TOKEN = 19
@@ -33,6 +34,7 @@ class MockGitHubAPI:
         self.patch_url: List[str] = []
         self.patch_data: List[str] = []
         self.delete_url: List[str] = []
+        self.delete_data: List[str] = []
 
     async def getitem(self, url, *, accept=sansio.accept_format(), oauth_token=None):
         self.getitem_url.append(url)
@@ -59,7 +61,8 @@ class MockGitHubAPI:
         return self._patch_return[url]
 
     async def delete(
-        self, url, *, data=b"", accept=sansio.accept_format(), oauth_token=None
+        self, url, *, data={}, accept=sansio.accept_format(), oauth_token=None
     ):
         self.delete_url.append(url)
+        self.delete_data.append(data)
         return self._delete_return[url]


### PR DESCRIPTION
# Detail changes

There are two handler functions for the `pull_request` event:
- `close_invalid_or_additional_pr`: Performs three mutually exclusive checks:
  - Check whether the description is empty or not, if it is then close the PR with an appropriate message
  - Check whether the checklist is completed or not, if it is not then close the PR with an appropriate message
  - Check whether the user already has an open PR, close the current PR if there is with an appropriate message. We can disable this check with `MAX_PR_BY_USER = 0`
- `check_pr_files`:
  - Check PR files for descriptive names, doctest and type hints. Comment the report when there are any errors but ***only when the PR is opened.*** This is done to avoid filling the PR with bot comments. The bot will add and remove appropriate labels.

# Highlighted changes

- Utilities function for the pull request event
- Improve Ratelimit log:
  - Add reset time remaining
  - Add which event triggered the callbacks and delivery id in one line
- Add global Label class to access any labels
- Add parser for checking PR files
- Remove labels can accept a list of labels
- Add ability to stop max pr checks by user
- Modified test utility class MockGitHubAPI for list
  - `delete` now stores data
- Update old test and add new ones for utils
- Search only open PRs in check run completed event
- Search gives us issue object related to the PR